### PR TITLE
Remove the temporary file in do_git_info()

### DIFF
--- a/git-info
+++ b/git-info
@@ -278,6 +278,8 @@ do_git_info () {
     }
     echo "Last Changed Log:"
     sed 's/^    /	/' "$TEMPFILE"
+
+    finalize
 }
 
 die () {


### PR DESCRIPTION
If do_git_info() is called in a pipeline, it runs in a subshell.  In
that case, the main shell doesn't know the value of TEMPFILE and can't
remove the temporary file.
